### PR TITLE
Allow AnyAdcChannel for ADC4

### DIFF
--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -163,8 +163,8 @@ pub struct AnyAdcChannel<T> {
     _phantom: PhantomData<T>,
 }
 impl_peripheral!(AnyAdcChannel<T: Instance>);
-impl<T: Instance> AdcChannel<T> for AnyAdcChannel<T> {}
-impl<T: Instance> SealedAdcChannel<T> for AnyAdcChannel<T> {
+impl<T> AdcChannel<T> for AnyAdcChannel<T> {}
+impl<T> SealedAdcChannel<T> for AnyAdcChannel<T> {
     fn channel(&self) -> u8 {
         self.channel
     }


### PR DESCRIPTION
AnyAdcChannel being restricted to a non-adc4 instance prevented AnyAdcChannel from working with ADC4 pins.